### PR TITLE
Inline functions

### DIFF
--- a/src/endian.rs
+++ b/src/endian.rs
@@ -16,23 +16,29 @@ pub struct BigEndian;
 pub struct LittleEndian;
 
 impl BitEndianness for BigEndian {
+    #[inline]
     fn shift_msb(val: u8, by: u8) -> u8 {
         val << by
     }
+    #[inline]
     fn shift_lsb(val: u8, by: u8) -> u8 {
         val >> by
     }
+    #[inline]
     fn align_right(val: u8, _count: u8) -> u8 {
         val
     }
 }
 impl BitEndianness for LittleEndian {
+    #[inline]
     fn shift_msb(val: u8, by: u8) -> u8 {
         val >> by
     }
+    #[inline]
     fn shift_lsb(val: u8, by: u8) -> u8 {
         val << by
     }
+    #[inline]
     fn align_right(val: u8, count: u8) -> u8 {
         Self::shift_msb(val, 8 - count)
     }

--- a/src/read.rs
+++ b/src/read.rs
@@ -43,6 +43,7 @@ impl<E: BitEndianness, R: Read> BitReader<E, R> {
     /// ```
     ///
     /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+    #[inline]
     pub fn new(inner: R) -> Self {
         Self {
             inner,
@@ -59,6 +60,7 @@ impl<E: BitEndianness, R: Read> BitReader<E, R> {
     }
 
     /// Aligns to byte boundary, discarding a partial byte if the `BitReader` was not aligned.
+    #[inline]
     pub fn align(&mut self) {
         self.bit_offset = 0;
         self.bit_buffer = 0;
@@ -74,6 +76,7 @@ impl<E: BitEndianness, R: Read> BitReader<E, R> {
     /// # let mut buf = [0; 1];
     /// # inner.read(&mut buf).unwrap();
     /// ```
+    #[inline]
     pub fn get_ref(&self) -> &R {
         &self.inner
     }
@@ -83,6 +86,7 @@ impl<E: BitEndianness, R: Read> BitReader<E, R> {
     /// Mutable operations on the underlying reader will corrupt this `BitReader` if it is not aligned, so the reference is only returned if the `BitReader` is aligned.
     ///
     /// Panics if the `BitReader` is not aligned.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut R {
         assert!(self.is_aligned(), "BitReader is not aligned");
         &mut self.inner
@@ -91,6 +95,7 @@ impl<E: BitEndianness, R: Read> BitReader<E, R> {
     /// Gets a mutable reference to the underlying reader.
     ///
     /// Use with care: Any reading/seeking/etc operation on the underlying reader will corrupt this `BitReader` if it is not aligned.
+    #[inline]
     pub unsafe fn get_mut_unchecked(&mut self) -> &mut R {
         &mut self.inner
     }
@@ -98,6 +103,7 @@ impl<E: BitEndianness, R: Read> BitReader<E, R> {
     /// Unwraps this `BitReader`, returning the underlying reader.
     ///
     /// Note that any partially read byte is lost.
+    #[inline]
     pub fn into_inner(self) -> R {
         self.inner
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -19,9 +19,11 @@ pub type LEBitWriter<W> = BitWriter<LE, W>;
 pub struct IntoInnerError<W>(W, std::io::Error);
 
 impl<W> IntoInnerError<W> {
+    #[inline]
     pub fn error(&self) -> &std::io::Error {
         &self.1
     }
+    #[inline]
     pub fn into_inner(self) -> W {
         self.0
     }
@@ -68,11 +70,13 @@ impl<E: BitEndianness, W: Write> BitWriter<E, W> {
     /// ```
     ///
     /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+    #[inline]
     pub fn new(inner: W) -> Self {
         Self::with_capacity(16, inner)
     }
 
     /// Creates a new `BitWriter` with an explicitly specified capacity for the buffer used in the `Write` implementation.
+    #[inline]
     pub fn with_capacity(capacity: usize, inner: W) -> Self {
         Self {
             inner: Some(inner),
@@ -90,6 +94,7 @@ impl<E: BitEndianness, W: Write> BitWriter<E, W> {
     }
 
     /// Aligns to byte boundary, skipping a partial byte if the `BitWriter` was not aligned.
+    #[inline]
     pub fn align(&mut self) -> Res<()> {
         if !self.is_aligned() {
             self.flush_buffer()?;
@@ -106,6 +111,7 @@ impl<E: BitEndianness, W: Write> BitWriter<E, W> {
     /// # let inner = writer.get_ref();
     /// # inner.clear();
     /// ```
+    #[inline]
     pub fn get_ref(&self) -> &W {
         self.inner.as_ref().unwrap()
     }
@@ -115,6 +121,7 @@ impl<E: BitEndianness, W: Write> BitWriter<E, W> {
     /// Mutable operations on the underlying writer will corrupt this `BitWriter` if it is not aligned, so the reference is only returned if the `BitWriter` is aligned.
     ///
     /// Panics if the `BitWriter` is not aligned.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut W {
         assert!(self.is_aligned(), "BitWriter is not aligned");
         self.inner.as_mut().unwrap()
@@ -123,6 +130,7 @@ impl<E: BitEndianness, W: Write> BitWriter<E, W> {
     /// Gets a mutable reference to the underlying writer.
     ///
     /// Use with care: Any writing/seeking/etc operation on the underlying writer will corrupt this `BitWriter` if it is not aligned.
+    #[inline]
     pub unsafe fn get_mut_unchecked(&mut self) -> &mut W {
         self.inner.as_mut().unwrap()
     }
@@ -130,6 +138,7 @@ impl<E: BitEndianness, W: Write> BitWriter<E, W> {
     /// Unwraps this `BitWriter`, returning the underlying writer.
     ///
     /// The buffer for partial writes will be flushed before returning the writer. If an error occurs during the flushing it will be returned.
+    #[inline]
     pub fn into_inner(mut self) -> Result<W, IntoInnerError<Self>> {
         match self.align() {
             Ok(()) => Ok(self.inner.take().unwrap()),
@@ -253,6 +262,7 @@ impl<E: BitEndianness, W: Write> Write for BitWriter<E, W> {
 
 /// Flushes the buffer for unaligned writes before the `BitWriter` is dropped.
 impl<E: BitEndianness, W: Write> Drop for BitWriter<E, W> {
+    #[inline]
     fn drop(&mut self) {
         let _ = self.align();
     }


### PR DESCRIPTION
Add `#[inline]` tag to some short functions that could benefit from inlining